### PR TITLE
Modified link URL to Google Fonts.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,7 @@
   -->
   <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/style.css">
   <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/css/pygments.css">
-  <link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=PT+Sans|PT+Serif|PT+Mono">
+  <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=PT+Sans|PT+Serif|PT+Mono">
 
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Link to Google Fonts is modified from http:// to // so that browsers won't block it when using https.